### PR TITLE
Add resetting of ults at end of Power Play

### DIFF
--- a/powerPlay.opy
+++ b/powerPlay.opy
@@ -57,6 +57,8 @@ rule "At end of Power Play, reset points":
     setMatchTime(resumeMatchTime)
     triggerPointReset()
     playSoundForAll()
+    if createWorkshopSetting(bool, "Power Play Settings", "Reset Ults When Power Play Ends", true, 3):
+        getAllPlayers().setUltCharge(0)
     # Use different sides from the previous Power Play
     swapSides = not swapSides
     # Reset spawns


### PR DESCRIPTION
The intention of this change is to prevent high levels of snowball from farming ult charge from a Power Play.